### PR TITLE
refactor: Consolidate test helpers into internal/testutil

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ make install-tools
 
 ### Mock Testing Interface
 
-Tests use a custom `mockT` type that implements the minimal `TestingT` interface
+Tests use a custom `MockT` type that implements the minimal `TestingT` interface
 rather than embedding `testing.T`. This allows capturing assertion output for
 verification.
 

--- a/README.md
+++ b/README.md
@@ -44,16 +44,13 @@ import (
 )
 
 func TestExample(t *testing.T) {
-    user := User{Name: "Alice", Age: 16}
+    x := 10
+    y := 20
     
     // Just write any Go expression!
-    diagassert.Assert(t, user.Age >= 18)
-    diagassert.Assert(t, user.HasLicense())
-    diagassert.Assert(t, user.Age >= 18 && user.HasLicense())
-    
-    // Works with any expression
-    diagassert.Assert(t, strings.Contains(user.Name, "A"))
-    diagassert.Assert(t, len(user.Name) > 0)
+    diagassert.Assert(t, x > y)
+    diagassert.Assert(t, x + y == 30)
+    diagassert.Assert(t, strings.Contains("hello", "lo"))
 }
 ```
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -116,8 +116,14 @@ FAIL_REASON: left_operand_false
 ## Usage Example
 
 ```go
+import (
+    "testing"
+    "github.com/paveg/diagassert"
+    "github.com/paveg/diagassert/internal/testutil"
+)
+
 func TestUserPermissions(t *testing.T) {
-    user := User{Name: "Alice", Age: 16}
+    user := testutil.User{Name: "Alice", Age: 16}
     
     // That's all! No special APIs needed
     diagassert.Assert(t, user.Age >= 18)

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/paveg/diagassert"
+	"github.com/paveg/diagassert/internal/testutil"
 )
 
 func TestExample_ActualOutput(t *testing.T) {
@@ -27,7 +28,7 @@ func TestExample_ActualOutput(t *testing.T) {
 func TestExample_Demo(t *testing.T) {
 	t.Log("Demo of diagassert output")
 
-	user := User{Name: "Alice", Age: 16}
+	user := testutil.User{Name: "Alice", Age: 16}
 
 	// Demo to see actual output (expecting failures)
 	if false {
@@ -37,18 +38,7 @@ func TestExample_Demo(t *testing.T) {
 	}
 }
 
-type User struct {
-	Name string
-	Age  int
-}
 
-func (u User) HasLicense() bool {
-	return false // Always returns false
-}
-
-func (u User) IsAdult() bool {
-	return u.Age >= 18
-}
 
 // Manual test to see actual failure output
 func TestExample_ManualFailure(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,57 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MockT is a mock implementation of the TestingT interface
+type MockT struct {
+	failed   bool
+	messages []string
+}
+
+func NewMockT() *MockT {
+	return &MockT{
+		messages: make([]string, 0),
+	}
+}
+
+func (m *MockT) Fatal(args ...interface{}) {
+	for _, arg := range args {
+		m.messages = append(m.messages, fmt.Sprint(arg))
+	}
+	m.failed = true
+	panic("FailNow called")
+}
+
+func (m *MockT) Error(args ...interface{}) {
+	for _, arg := range args {
+		m.messages = append(m.messages, fmt.Sprint(arg))
+	}
+	m.failed = true
+}
+
+func (m *MockT) Helper() {}
+
+func (m *MockT) Failed() bool {
+	return m.failed
+}
+
+func (m *MockT) GetOutput() string {
+	return strings.Join(m.messages, "\n")
+}
+
+// Test struct
+type User struct {
+	Name string
+	Age  int
+}
+
+func (u User) IsAdult() bool {
+	return u.Age >= 18
+}
+
+func (u User) HasLicense() bool {
+	return false // Always returns false
+}

--- a/original_request_test.go
+++ b/original_request_test.go
@@ -5,50 +5,20 @@ import (
 	"testing"
 
 	"github.com/paveg/diagassert"
+	"github.com/paveg/diagassert/internal/testutil"
 )
 
 // Test for value capture functionality - Original Request Test Cases
 
-type mockT struct {
-	output string
-	failed bool
-}
-
-func (m *mockT) Error(args ...interface{}) {
-	m.failed = true
-	if len(args) > 0 {
-		m.output = args[0].(string)
-	}
-}
-
-func (m *mockT) Fatal(args ...interface{}) {
-	m.failed = true
-	if len(args) > 0 {
-		m.output = args[0].(string)
-	}
-}
-
-func (m *mockT) Helper() {}
-
-func newMockT() *mockT {
-	return &mockT{}
-}
-
-func (m *mockT) getOutput() string {
-	return m.output
-}
-
-// User type is already defined in example_test.go
-
 func TestAssert_WithValueCapture(t *testing.T) {
 	t.Run("single value capture", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 
 		// Provide values using V() helper
 		diagassert.Assert(mock, x > 20, diagassert.V("x", x))
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		// Verify that values are displayed
 		if !strings.Contains(output, "x = 10") {
@@ -57,7 +27,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("multiple value captures", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x, y := 10, 20
 
 		// Capture multiple values
@@ -65,7 +35,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			diagassert.V("x", x),
 			diagassert.V("y", y))
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		if !strings.Contains(output, "x = 10") || !strings.Contains(output, "y = 20") {
 			t.Errorf("Should show all captured values, got: %s", output)
@@ -73,7 +43,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("values map", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		age := 16
 		hasLicense := false
 
@@ -84,7 +54,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 				"hasLicense": hasLicense,
 			})
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		if !strings.Contains(output, "age = 16") {
 			t.Errorf("Should show age value, got: %s", output)
@@ -95,7 +65,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("with custom message", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 
 		// Combination of value capture and custom message
@@ -103,7 +73,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			diagassert.V("x", x),
 			"Expected x to be greater than 20")
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		if !strings.Contains(output, "x = 10") {
 			t.Errorf("Should show value, got: %s", output)
@@ -114,8 +84,8 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("complex expression with values", func(t *testing.T) {
-		mock := newMockT()
-		user := User{Name: "Alice", Age: 16}
+		mock := testutil.NewMockT()
+		user := testutil.User{Name: "Alice", Age: 16}
 		minAge := 18
 
 		diagassert.Assert(mock, user.Age >= minAge && user.IsAdult(),
@@ -125,7 +95,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 				"user":     user,
 			})
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		// Structured evaluation tree is displayed
 		if !strings.Contains(output, "EVALUATION TRACE:") {
@@ -142,10 +112,10 @@ func TestAssert_WithValueCapture(t *testing.T) {
 func TestAssert_NoValueCapture(t *testing.T) {
 	// Basic functionality works even without value capture
 	t.Run("basic functionality without value capture", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		diagassert.Assert(mock, false)
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		// Basic failure message is displayed
 		if !strings.Contains(output, "ASSERTION FAILED") {
@@ -154,11 +124,11 @@ func TestAssert_NoValueCapture(t *testing.T) {
 	})
 
 	t.Run("expression shown without values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 		diagassert.Assert(mock, x > 20)
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		// Expression is displayed
 		if !strings.Contains(output, "x > 20") {
@@ -175,14 +145,14 @@ func TestAssert_NoValueCapture(t *testing.T) {
 
 func TestAssert_OptionalValueCapture(t *testing.T) {
 	// Value capture is completely optional
-	mock := newMockT()
+	mock := testutil.NewMockT()
 	x, y, z := 10, 20, 30
 
 	// Provide only some values
 	diagassert.Assert(mock, x > y && y < z,
 		diagassert.V("y", y)) // Provide only y value
 
-	output := mock.getOutput()
+	output := mock.GetOutput()
 
 	// Provided values are displayed
 	if !strings.Contains(output, "y = 20") {

--- a/phase2_demo_test.go
+++ b/phase2_demo_test.go
@@ -6,29 +6,8 @@ import (
 	"testing"
 
 	"github.com/paveg/diagassert"
+	"github.com/paveg/diagassert/internal/testutil"
 )
-
-// mockTestingT captures test output for validation
-type mockTestingT struct {
-	output string
-	failed bool
-}
-
-func (m *mockTestingT) Error(args ...interface{}) {
-	m.failed = true
-	if len(args) > 0 {
-		m.output = args[0].(string)
-	}
-}
-
-func (m *mockTestingT) Fatal(args ...interface{}) {
-	m.failed = true
-	if len(args) > 0 {
-		m.output = args[0].(string)
-	}
-}
-
-func (m *mockTestingT) Helper() {}
 
 // TestPhase2OutputDemo demonstrates Phase 2 enhanced output
 func TestPhase2OutputDemo(t *testing.T) {
@@ -39,12 +18,12 @@ func TestPhase2OutputDemo(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		assertion     func(*mockTestingT)
+		assertion     func(*testutil.MockT)
 		expectedParts []string
 	}{
 		{
 			name: "simple comparison with enhanced output",
-			assertion: func(mock *mockTestingT) {
+			assertion: func(mock *testutil.MockT) {
 				x := 10
 				diagassert.Assert(mock, x > 20)
 			},
@@ -60,7 +39,7 @@ func TestPhase2OutputDemo(t *testing.T) {
 		},
 		{
 			name: "logical expression with enhanced output",
-			assertion: func(mock *mockTestingT) {
+			assertion: func(mock *testutil.MockT) {
 				age := 16
 				hasLicense := false
 				diagassert.Assert(mock, age >= 18 && hasLicense)
@@ -78,19 +57,19 @@ func TestPhase2OutputDemo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mock := &mockTestingT{}
+			mock := testutil.NewMockT()
 			tt.assertion(mock)
 
-			if !mock.failed {
+			if !mock.Failed() {
 				t.Error("Expected assertion to fail")
 				return
 			}
 
-			t.Logf("Phase 2 Output:\n%s", mock.output)
+			t.Logf("Phase 2 Output:\n%s", mock.GetOutput())
 
 			// Verify expected parts are present
 			for _, expected := range tt.expectedParts {
-				if !strings.Contains(mock.output, expected) {
+				if !strings.Contains(mock.GetOutput(), expected) {
 					t.Errorf("Expected output to contain %q", expected)
 				}
 			}
@@ -100,22 +79,17 @@ func TestPhase2OutputDemo(t *testing.T) {
 
 // TestPhase2StructFieldDemo demonstrates struct field evaluation
 func TestPhase2StructFieldDemo(t *testing.T) {
-	type User struct {
-		Name string
-		Age  int
-	}
-
-	user := User{Name: "Alice", Age: 16}
-	mock := &mockTestingT{}
+	user := testutil.User{Name: "Alice", Age: 16}
+	mock := testutil.NewMockT()
 
 	diagassert.Assert(mock, user.Age >= 18)
 
-	if !mock.failed {
+	if !mock.Failed() {
 		t.Error("Expected assertion to fail")
 		return
 	}
 
-	t.Logf("Struct Field Output:\n%s", mock.output)
+	t.Logf("Struct Field Output:\n%s", mock.GetOutput())
 
 	// Check for Phase 2 features
 	expectedParts := []string{
@@ -126,7 +100,7 @@ func TestPhase2StructFieldDemo(t *testing.T) {
 	}
 
 	for _, expected := range expectedParts {
-		if !strings.Contains(mock.output, expected) {
+		if !strings.Contains(mock.GetOutput(), expected) {
 			t.Errorf("Expected output to contain %q", expected)
 		}
 	}

--- a/value_capture_comprehensive_test.go
+++ b/value_capture_comprehensive_test.go
@@ -3,24 +3,26 @@ package diagassert
 import (
 	"strings"
 	"testing"
+
+	"github.com/paveg/diagassert/internal/testutil"
 )
 
-// Note: Using mockT and User from assert_test.go to avoid redeclaration
+// Note: Using MockT and User from assert_test.go to avoid redeclaration
 
 // TestAssert_WithValueCapture tests assertion failures with comprehensive value capture functionality
 func TestAssert_WithValueCapture(t *testing.T) {
 	t.Run("single_value_with_V", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 
 		// Test the exact API pattern: diagassert.V("x", x)
 		Assert(mock, x > 20, V("x", x))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -30,18 +32,18 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("multiple_values_with_Values_map", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 		y := 5
 
 		// Test the exact API pattern: diagassert.Values{"x": x, "y": y}
 		Assert(mock, x < y, Values{"x": x, "y": y})
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -54,7 +56,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("mixed_V_and_Values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		a := 10
 		b := 20
 		c := 30
@@ -62,11 +64,11 @@ func TestAssert_WithValueCapture(t *testing.T) {
 		// Test mixing V() and Values{} in the same assertion
 		Assert(mock, a > b, V("a", a), Values{"b": b, "c": c})
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -82,7 +84,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("custom_message_with_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		score := 65
 		passingScore := 70
 
@@ -92,11 +94,11 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			V("score", score),
 			V("passingScore", passingScore))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -115,8 +117,8 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("complex_struct_values", func(t *testing.T) {
-		mock := newMockT()
-		user := User{Name: "Alice", Age: 16}
+		mock := testutil.NewMockT()
+		user := testutil.User{Name: "Alice", Age: 16}
 		minAge := 18
 
 		// Test capturing complex struct values
@@ -126,11 +128,11 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			V("user.Age", user.Age),
 			V("minAge", minAge))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -146,7 +148,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("multiple_messages_with_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 5
 		y := 10
 
@@ -158,11 +160,11 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			V("y", y),
 			"Final validation message")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -181,7 +183,7 @@ func TestAssert_WithValueCapture(t *testing.T) {
 	})
 
 	t.Run("type_information_in_output", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		intVal := 42
 		strVal := "hello"
 		boolVal := true
@@ -194,11 +196,11 @@ func TestAssert_WithValueCapture(t *testing.T) {
 			V("boolVal", boolVal),
 			V("floatVal", floatVal))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "intVal = 42 (int)") {
 			t.Errorf("Should show int type, got: %s", output)
 		}
@@ -217,16 +219,16 @@ func TestAssert_WithValueCapture(t *testing.T) {
 // TestAssert_NoValueCapture tests assertions without any value capture (backward compatibility)
 func TestAssert_NoValueCapture(t *testing.T) {
 	t.Run("original_API_still_works", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 
 		// Test the original simple API
 		Assert(mock, false)
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "ASSERTION FAILED") {
 			t.Errorf("Should contain assertion failed message, got: %s", output)
 		}
@@ -239,18 +241,18 @@ func TestAssert_NoValueCapture(t *testing.T) {
 	})
 
 	t.Run("expression_evaluation_without_capture", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 		y := 20
 
 		// Test complex expression without value capture
 		Assert(mock, x > y && y < 15)
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "ASSERTION FAILED") {
 			t.Errorf("Should contain assertion failed message, got: %s", output)
 		}
@@ -267,16 +269,16 @@ func TestAssert_NoValueCapture(t *testing.T) {
 // TestAssert_OptionalValueCapture tests various combinations of optional value capture
 func TestAssert_OptionalValueCapture(t *testing.T) {
 	t.Run("message_only_no_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 
 		// Test custom message without value capture
 		Assert(mock, false, "This is just a custom message")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -289,18 +291,18 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 	})
 
 	t.Run("values_only_no_message", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 100
 		y := 50
 
 		// Test value capture without custom message
 		Assert(mock, x < y, V("x", x), V("y", y))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -316,16 +318,16 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 	})
 
 	t.Run("empty_Values_map", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 
 		// Test with empty Values map
 		Assert(mock, false, Values{}, "Message with empty values")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -335,7 +337,7 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 	})
 
 	t.Run("nil_and_zero_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		var nilPtr *string
 		zeroInt := 0
 		emptyString := ""
@@ -347,11 +349,11 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 			V("zeroInt", zeroInt),
 			V("emptyString", emptyString))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -367,7 +369,7 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 	})
 
 	t.Run("interleaved_messages_and_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		a := 1
 		b := 2
 		c := 3
@@ -380,11 +382,11 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 			Values{"b": b, "c": c},
 			"End message")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -409,7 +411,7 @@ func TestAssert_OptionalValueCapture(t *testing.T) {
 // TestRequire_WithValueCapture tests the Require function with value capture
 func TestRequire_WithValueCapture(t *testing.T) {
 	t.Run("require_with_value_capture_should_panic", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 5
 
 		defer func() {
@@ -424,11 +426,11 @@ func TestRequire_WithValueCapture(t *testing.T) {
 			V("x", x),
 			V("threshold", 10))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Require should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -450,7 +452,7 @@ func TestRequire_WithValueCapture(t *testing.T) {
 // TestValueCapture_MachineReadableOutput tests that machine-readable output includes captured values
 func TestValueCapture_MachineReadableOutput(t *testing.T) {
 	t.Run("machine_readable_includes_captured_values", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 42
 		message := "Test message"
 
@@ -459,11 +461,11 @@ func TestValueCapture_MachineReadableOutput(t *testing.T) {
 			message,
 			V("x", x))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "[MACHINE_READABLE_START]") {
 			t.Errorf("Should contain machine readable section, got: %s", output)
 		}

--- a/value_capture_demo_test.go
+++ b/value_capture_demo_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/paveg/diagassert"
+	"github.com/paveg/diagassert/internal/testutil"
 )
 
 // ValueCaptureDemo demonstrates the enhanced output with value capture
@@ -15,17 +16,17 @@ func TestValueCaptureDemo(t *testing.T) {
 	t.Log("=== Demo of Value Capture API ===")
 
 	// Create a mock to capture output
-	mock := &mockT{}
+	mock := testutil.NewMockT()
 
 	// Demo 1: Simple value capture
 	t.Log("\n--- Demo 1: Simple Value Capture ---")
 	x := 15
 	diagassert.Assert(mock, x > 20, diagassert.V("x", x))
-	t.Logf("Output:\n%s", mock.getOutput())
+	t.Logf("Output:\n%s", mock.GetOutput())
 
 	// Demo 2: Multiple values with custom message
 	t.Log("\n--- Demo 2: Multiple Values with Custom Message ---")
-	mock = &mockT{}
+	mock = testutil.NewMockT()
 	age := 16
 	hasLicense := false
 	diagassert.Assert(mock, age >= 18 && hasLicense,
@@ -34,23 +35,23 @@ func TestValueCaptureDemo(t *testing.T) {
 			"hasLicense": hasLicense,
 		},
 		"User permission check failed")
-	t.Logf("Output:\n%s", mock.getOutput())
+	t.Logf("Output:\n%s", mock.GetOutput())
 
 	// Demo 3: Complex struct with method calls
 	t.Log("\n--- Demo 3: Complex Struct with Method Calls ---")
-	mock = &mockT{}
-	user := User{Name: "Alice", Age: 16}
+	mock = testutil.NewMockT()
+	user := testutil.User{Name: "Alice", Age: 16}
 	minAge := 18
 	diagassert.Assert(mock, user.Age >= minAge && user.IsAdult(),
 		diagassert.V("user", user),
 		diagassert.V("user.Age", user.Age),
 		diagassert.V("minAge", minAge),
 		"Age verification failed")
-	t.Logf("Output:\n%s", mock.getOutput())
+	t.Logf("Output:\n%s", mock.GetOutput())
 
 	// Demo 4: Mixed values and messages
 	t.Log("\n--- Demo 4: Mixed Values and Messages ---")
-	mock = &mockT{}
+	mock = testutil.NewMockT()
 	a, b, c := 10, 20, 30
 	diagassert.Assert(mock, a > b && b > c,
 		"First condition check",
@@ -59,5 +60,5 @@ func TestValueCaptureDemo(t *testing.T) {
 		diagassert.V("b", b),
 		diagassert.V("c", c),
 		"All values should form descending sequence")
-	t.Logf("Output:\n%s", mock.getOutput())
+	t.Logf("Output:\n%s", mock.GetOutput())
 }

--- a/values_test.go
+++ b/values_test.go
@@ -3,22 +3,24 @@ package diagassert
 import (
 	"strings"
 	"testing"
+
+	"github.com/paveg/diagassert/internal/testutil"
 )
 
 // TestAPI_ValueCapture tests the new API for value capture and custom messages
 func TestAPI_ValueCapture(t *testing.T) {
 	t.Run("single value capture with V()", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 
 		// Test the exact usage pattern: diagassert.V("x", x)
 		Assert(mock, x > 20, V("x", x))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -28,18 +30,18 @@ func TestAPI_ValueCapture(t *testing.T) {
 	})
 
 	t.Run("multiple values with Values map", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 		y := 5
 
 		// Test the exact usage pattern: diagassert.Values{"x": x, "y": y}
 		Assert(mock, x < y, Values{"x": x, "y": y})
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -52,17 +54,17 @@ func TestAPI_ValueCapture(t *testing.T) {
 	})
 
 	t.Run("custom message as string", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		condition := false
 
 		// Test custom messages as strings
 		Assert(mock, condition, "This is a custom error message")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -72,18 +74,18 @@ func TestAPI_ValueCapture(t *testing.T) {
 	})
 
 	t.Run("mixed usage: values + messages", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 		y := 5
 
 		// Test mixing values and messages
 		Assert(mock, x < y, V("x", x), "Values should be ordered", V("y", y))
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
 			t.Errorf("Should contain custom message section, got: %s", output)
 		}
@@ -102,7 +104,7 @@ func TestAPI_ValueCapture(t *testing.T) {
 	})
 
 	t.Run("complex mixed usage", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		user := struct {
 			Name string
 			Age  int
@@ -117,11 +119,11 @@ func TestAPI_ValueCapture(t *testing.T) {
 			Values{"user.Name": user.Name, "required": "adult"},
 			"Expected user to be an adult")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 
 		// Check for custom messages
 		if !strings.Contains(output, "CUSTOM MESSAGE:") {
@@ -156,16 +158,16 @@ func TestAPI_ValueCapture(t *testing.T) {
 // TestAPI_BackwardCompatibility ensures the original API still works
 func TestAPI_BackwardCompatibility(t *testing.T) {
 	t.Run("original API without additional args", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 
 		// Test that the original API still works
 		Assert(mock, false)
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Assert should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "ASSERTION FAILED") {
 			t.Errorf("Should contain assertion failed message, got: %s", output)
 		}
@@ -183,7 +185,7 @@ func TestAPI_BackwardCompatibility(t *testing.T) {
 // TestRequire_ValueCapture tests the Require function with value capture
 func TestRequire_ValueCapture(t *testing.T) {
 	t.Run("require with value capture", func(t *testing.T) {
-		mock := newMockT()
+		mock := testutil.NewMockT()
 		x := 10
 
 		defer func() {
@@ -195,11 +197,11 @@ func TestRequire_ValueCapture(t *testing.T) {
 		// Test Require with value capture
 		Require(mock, x > 20, V("x", x), "Critical condition failed")
 
-		if !mock.failed {
+		if !mock.Failed() {
 			t.Error("Require should have failed")
 		}
 
-		output := mock.getOutput()
+		output := mock.GetOutput()
 		if !strings.Contains(output, "CAPTURED VALUES:") {
 			t.Errorf("Should contain captured values section, got: %s", output)
 		}
@@ -289,4 +291,4 @@ func TestAssertionContext(t *testing.T) {
 	})
 }
 
-// Note: Using mockT and newMockT from assert_test.go
+// Note: Using MockT and newMockT from assert_test.go


### PR DESCRIPTION
- Move mockT and User structs, and related helper functions to internal/testutil package.
- Update all test files (assert_test.go, original_request_test.go, value_capture_comprehensive_test.go, example_test.go, phase2_demo_test.go, values_test.go) to import and use testutil.
- Update Go code snippets in README.md and docs/philosophy.md to reflect the changes.
- Ensure all tests pass after refactoring.