### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Test
 
+permissions:
+  contents: read
+  actions: write
+  checks: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/paveg/diagassert/security/code-scanning/1](https://github.com/paveg/diagassert/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden at the job level. Based on the workflow's steps, the minimal permissions required are:
- `contents: read` for accessing repository contents.
- `actions: write` for caching Go modules (required by `actions/cache`).
- `checks: write` for uploading test coverage to Codecov.

We will add this `permissions` block at the top level of the workflow file, ensuring all jobs inherit these permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
